### PR TITLE
Simplify physac.h build and linking process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.zig-cache/
+zig-out/

--- a/build.zig
+++ b/build.zig
@@ -17,19 +17,15 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
-    const gen_step = b.addWriteFiles();
-    lib.step.dependOn(&gen_step.step);
-
-    const physac_c_path = gen_step.add("physac.c",
-        \\#define PHYSAC_IMPLEMENTATION
-        \\#define PHYSAC_STANDALONE
-        \\#include "physac.h"
-    );
-    lib.addCSourceFile(.{ .file = physac_c_path });
-    lib.addIncludePath(physac_c_dep.path("src"));
     lib.linkLibC();
-
-    lib.installHeader(physac_c_dep.path("src/physac.h"), "physac.h");
+    lib.addIncludePath(physac_c_dep.path("src"));
+    lib.addCSourceFile(.{
+        .file = physac_c_dep.path("src/physac.h"),
+        .flags = &.{
+            "-DPHYSAC_IMPLEMENTATION",
+            "-DPHYSAC_STANDALONE",
+        },
+    });
 
     b.installArtifact(lib);
 


### PR DESCRIPTION
Also added .gitignore for `.zig-cache/` and `zig-out/`